### PR TITLE
Create head-background-image

### DIFF
--- a/head-background-image
+++ b/head-background-image
@@ -1,0 +1,3 @@
+.pkp_structure_head {
+    background-image: url(/ojs/public/site/images/[Nutzername]/[Image.jpg]);
+}


### PR DESCRIPTION
Mit diesem Stil kann die Hintergrundgrafik im Kopfbereich der OJS-Zeitschrift verändert werden.
Voraussetzung: Eine entsprechende Grafik liegt vor. Im Beispiel wurde eine Grafik in einer statischen Seite eingebettet, welche von OJS automatisch im persönlichen Nutzerverzeichnis abgelegt wird, wenn man diese via Editor eingefügt hat.